### PR TITLE
Simple array and composition property values

### DIFF
--- a/src/Enterspeed/Enterspeed.Migrator/Enterspeed/PagesResolver.cs
+++ b/src/Enterspeed/Enterspeed.Migrator/Enterspeed/PagesResolver.cs
@@ -175,56 +175,20 @@ namespace Enterspeed.Migrator.Enterspeed
                 var arrayOfElements = jsonProperty.Value.EnumerateArray();
                 foreach (var element in arrayOfElements)
                 {
-                    switch (element.ValueKind)
+                    if (element.ValueKind == JsonValueKind.Object)
                     {
-                        case JsonValueKind.Undefined:
-                            break;
-                        case JsonValueKind.Object:
-                            var objectOfElement = element.EnumerateObject();
-                            var newArrayItem = new EnterspeedPropertyType()
-                            {
-                                Name = "arrayObject",
-                                Alias = "arrayObject",
-                                Type = JsonValueKind.Object,
-                                Value = objectOfElement
-                            };
+                        var objectOfElement = element.EnumerateObject();
+                        var newArrayItem = new EnterspeedPropertyType()
+                        {
+                            Name = "arrayObject",
+                            Alias = "arrayObject",
+                            Type = JsonValueKind.Object,
+                            Value = objectOfElement
+                        };
 
-                            // Add arrayitem directly to array property
-                            currentProperty.ChildProperties.Add(newArrayItem);
-                            MapData(pageData, element, newArrayItem);
-                            break;
-                        case JsonValueKind.Array:
-                            break;
-                        case JsonValueKind.String:
-                            var stringItem = new EnterspeedPropertyType()
-                            {
-                                Name = "string",
-                                Alias = "string",
-                                Type = JsonValueKind.String,
-                                Value = element.GetString()
-                            };
-
-                            // Add arrayitem directly to array property
-                            currentProperty.ChildProperties.Add(stringItem);
-                            break;
-                        case JsonValueKind.Number:
-                            var numberItem = new EnterspeedPropertyType()
-                            {
-                                Name = "string",
-                                Alias = "string",
-                                Type = JsonValueKind.String,
-                                Value = element.GetInt32()
-                            };
-
-                            // Add arrayItem directly to array property
-                            currentProperty.ChildProperties.Add(numberItem);
-                            break;
-                        case JsonValueKind.True:
-                            break;
-                        case JsonValueKind.False:
-                            break;
-                        case JsonValueKind.Null:
-                            break;
+                        // Add arrayitem directly to array property
+                        currentProperty.ChildProperties.Add(newArrayItem);
+                        MapData(pageData, element, newArrayItem);
                     }
                 }
 

--- a/src/Migrators/Umbraco/Umbraco.Migrator/Content/ContentBuilder.cs
+++ b/src/Migrators/Umbraco/Umbraco.Migrator/Content/ContentBuilder.cs
@@ -64,7 +64,7 @@ namespace Umbraco.Migrator.Content
             }
         }
 
-        public void CreateProperties(List<EnterspeedPropertyType> properties, IContent contentToCreate, List<EnterspeedPropertyType> components, bool isTraversing = false)
+        public void CreateProperties(List<EnterspeedPropertyType> properties, IContent contentToCreate, List<EnterspeedPropertyType> components)
         {
             foreach (var property in properties)
             {
@@ -77,7 +77,7 @@ namespace Umbraco.Migrator.Content
 
                 if (property.ChildProperties.Any())
                 {
-                    CreateProperties(property.ChildProperties, contentToCreate, components, true);
+                    CreateProperties(property.ChildProperties, contentToCreate, components);
                 }
                 else
                 {

--- a/src/Migrators/Umbraco/Umbraco.Migrator/Content/ContentBuilder.cs
+++ b/src/Migrators/Umbraco/Umbraco.Migrator/Content/ContentBuilder.cs
@@ -68,12 +68,6 @@ namespace Umbraco.Migrator.Content
         {
             foreach (var property in properties)
             {
-                // Since we are not traversing and looking for components, we want to add the value to the property found.
-                if (!isTraversing)
-                {
-                    AddValueToProperty(property, contentToCreate);
-                }
-
                 // A component has been found, which will be resolved, values assigned to properties and added to list property that is set up in umbraco
                 if (property.IsComponent())
                 {
@@ -84,6 +78,10 @@ namespace Umbraco.Migrator.Content
                 if (property.ChildProperties.Any())
                 {
                     CreateProperties(property.ChildProperties, contentToCreate, components, true);
+                }
+                else
+                {
+                    AddValueToProperty(property, contentToCreate);
                 }
             }
         }

--- a/src/Migrators/Umbraco/Umbraco.Migrator/DocumentTypes/DocumentTypeBuilder.cs
+++ b/src/Migrators/Umbraco/Umbraco.Migrator/DocumentTypes/DocumentTypeBuilder.cs
@@ -225,6 +225,13 @@ namespace Umbraco.Migrator.DocumentTypes
                     break;
                 case JsonValueKind.Array:
                     // Check if we are a component or simple type of array
+                    var elementValueKind = GetValueKindOfFirstElementInArray(enterspeedProperty);
+
+                    if (elementValueKind is JsonValueKind.String or JsonValueKind.Number)
+                    {
+                        dataType = _dataTypes.Find(d => d.Name?.ToLower() == "tags");
+                    }
+
                     break;
                 case JsonValueKind.String:
                     dataType = _dataTypes.Find(d => d.Name?.ToLower() == "textstring");
@@ -281,6 +288,19 @@ namespace Umbraco.Migrator.DocumentTypes
 
             var existingContainer = _contentTypeService.GetContainers(folderName, 1).FirstOrDefault();
             return existingContainer;
+        }
+
+        private static JsonValueKind GetValueKindOfFirstElementInArray(EnterspeedPropertyType enterspeedProperty)
+        {
+            var valueKind = JsonValueKind.Undefined;
+            var array = ((JsonElement)enterspeedProperty.Value).EnumerateArray().ToArray();
+
+            if (array.Any())
+            {
+                valueKind = array.First().ValueKind;
+            }
+
+            return valueKind;
         }
     }
 }


### PR DESCRIPTION
This PR contains two changes:

- Properties of simple array types like string and number are now supported and created using the Umbraco.Tags property type (we use the tags property type because it doesn't require predefined values on the datatype)
- Fixes property values for compositions. Prior to this PR properties on compositions was never given a value when migrating content. See example of types on below screenshot

![image](https://user-images.githubusercontent.com/2575817/236824882-8657b423-52aa-4929-8bf7-178136039f61.png)
