### PR TITLE
Fixed null exception when settings arrays are empty

### DIFF
--- a/src/Enterspeed/Enterspeed.Migrator/Settings/EnterspeedConfiguration.cs
+++ b/src/Enterspeed/Enterspeed.Migrator/Settings/EnterspeedConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Enterspeed.Migrator.Settings
+﻿using System;
+
+namespace Enterspeed.Migrator.Settings
 {
     public class EnterspeedConfiguration
     {
@@ -6,6 +8,6 @@
         public string ApiKey { get; init; }
         public string NavigationHandle { get; set; }
         public string MigrationPageMetaData { get; set; }
-        public string[] ComponentPropertyTypeKeys { get; set; }
+        public string[] ComponentPropertyTypeKeys { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/Migrators/Umbraco/Umbraco.Migrator/Settings/UmbracoMigrationConfiguration.cs
+++ b/src/Migrators/Umbraco/Umbraco.Migrator/Settings/UmbracoMigrationConfiguration.cs
@@ -1,10 +1,12 @@
-﻿namespace Umbraco.Migrator.Settings
+﻿using System;
+
+namespace Umbraco.Migrator.Settings
 {
     public class UmbracoMigrationConfiguration
     {
         public static string ConfigurationKey => "UmbracoMigrationConfiguration";
         public string RootDocType { get; set; }
-        public string[] CompositionKeys { get; set; }
+        public string[] CompositionKeys { get; set; } = Array.Empty<string>();
         public string ContentPropertyAlias { get; set; }
     }
 }


### PR DESCRIPTION
Fixed null exception when settings arrays are empty by initializing them as emtpty array instead of null